### PR TITLE
Added Docker support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:2.3.0-slim
+
+RUN apt-get update
+RUN apt-get install dnsutils -y
+
+RUN mkdir /app
+WORKDIR /app
+ADD . .
+RUN bundle install
+
+ENTRYPOINT ["bundle", "exec", "ruby", "main.rb"]

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Quick hack to use the letsencrypt [DNS challenge](https://letsencrypt.github.io/acme-spec/#rfc.section.7.4) with dnsimple.
 
-## Running
+## Running (Ruby)
 
-Requires ruby 2.3.0.
+Requires Ruby 2.3.0.
 
 ```bash
 $ gem install bundler
@@ -15,6 +15,22 @@ $ DNSIMPLE_API_USER=you@foo.org \
   ACME_CONTACT=mailto:you@foo.org \
   bundle exec ruby main.rb
 ```
+
+## Running (Docker)
+
+Requires Docker (Ruby not required).
+
+```bash
+$ docker run \
+  -e DNSIMPLE_API_USER=you@foo.org \
+  -e DNSIMPLE_API_TOKEN=... \
+  -e NAMES=foo.org,www/foo.org \
+  -e ACME_CONTACT=mailto:you@foo.org \
+  -v $(pwd)/live:/app/live \
+  -ti meskyanichi/letsencrypt-dnsimple
+```
+
+## Result
 
 `.pem` files will be written to files named after the value of `NAMES`, with the above config they would match `foo.org_www.foo.org-*`:
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ $ DNSIMPLE_API_USER=you@foo.org \
 `.pem` files will be written to files named after the value of `NAMES`, with the above config they would match `foo.org_www.foo.org-*`:
 
 ```
-foo.org_www.foo.org-cert.pem
-foo.org_www.foo.org-chain.pem
-foo.org_www.foo.org-fullchain.pem
-foo.org_www.foo.org-key.pem
+./live/foo.org_www.foo.org-cert.pem
+./live/foo.org_www.foo.org-chain.pem
+./live/foo.org_www.foo.org-fullchain.pem
+./live/foo.org_www.foo.org-privkey.pem
 ```
 
 ## Config

--- a/main.rb
+++ b/main.rb
@@ -1,3 +1,4 @@
+require "fileutils"
 require "openssl"
 require "shellwords"
 
@@ -91,7 +92,8 @@ csr = Acme::Client::CertificateRequest.new(names: authorize_names.keys)
 puts "requesting certificate"
 certificate = acme.new_certificate(csr)
 
-File.write("#{filename_base}-key.pem", certificate.request.private_key.to_pem)
-File.write("#{filename_base}-cert.pem", certificate.to_pem)
-File.write("#{filename_base}-chain.pem", certificate.chain_to_pem)
-File.write("#{filename_base}-fullchain.pem", certificate.fullchain_to_pem)
+FileUtils.mkdir_p("live")
+File.write("live/#{filename_base}-privkey.pem", certificate.request.private_key.to_pem)
+File.write("live/#{filename_base}-cert.pem", certificate.to_pem)
+File.write("live/#{filename_base}-chain.pem", certificate.chain_to_pem)
+File.write("live/#{filename_base}-fullchain.pem", certificate.fullchain_to_pem)


### PR DESCRIPTION
First of all, thanks for this awesome utility!

I've Dockerized it to make it more distributable, and so that the end-user doesn't have to install Ruby and its dependencies to use it.

Assuming you have Docker installed, you can simply run it like so:

``` bash
$ docker run \
  -e DNSIMPLE_API_USER=you@foo.org \
  -e DNSIMPLE_API_TOKEN=... \
  -e NAMES=foo.org,www/foo.org \
  -e ACME_CONTACT=mailto:you@foo.org \
  -v $(pwd)/live:/app/live \
  -ti meskyanichi/letsencrypt-dnsimple
```

Feel free to pull this in if you like. If you do, you probably want to setup automated builds against this repository on hub.docker.com so that the image automatically rebuilds on each git push. Then you can change `meskyanichi/letsencrypt-dnsimple` to `dpiddy/letsencrypt-dnsimple` in the README.

See commit messages for other small changes.
