### PR TITLE
Adds output file base override config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ Comes from the environment.
 * `NAMES`: a `,`-separated list of names that will be in the requested cert. Use `/` instead of `.` to denote the separation between subdomain and dnsimple domain. For example, to request a cert for `www.danp.net`, where `danp.net` is the domain dnsimple knows about, you'd use `www/danp.net`.
 * `ACME_CONTACT`: the contact to use for [registration](https://letsencrypt.github.io/acme-spec/#rfc.section.6.3)
 * `LETSENCRYPT_ENDPOINT`: optional, defaults to the production endpoint at `https://acme-v01.api.letsencrypt.org/`
+* `OUTPUT_FILE_BASE`: optional, if specified, overrides the output filename base

--- a/main.rb
+++ b/main.rb
@@ -84,7 +84,7 @@ authorize_names.each do |authorize_name, authorize_domain_name|
   end
 end
 
-filename_base = authorize_names.keys.sort.join("_")
+filename_base = ENV["OUTPUT_FILE_BASE"] || authorize_names.keys.sort.join("_")
 
 csr = Acme::Client::CertificateRequest.new(names: authorize_names.keys)
 


### PR DESCRIPTION
I had an error running this because I'm trying to request **9** names, which results in an output file name that's too long. So I've written another config option that lets you specify the output filename base, which is handy if you really want a specific output name or if you run into an error like I did:

```../main.rb:94:in `write': Filename too long @ rb_sysopen - all_of_my_names.example.com-key.pem (Errno::ENAMETOOLONG)```